### PR TITLE
add ulidgen

### DIFF
--- a/ulidgen/.dockerignore
+++ b/ulidgen/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/ulidgen/Dockerfile
+++ b/ulidgen/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:alpine as build
+WORKDIR /build
+RUN apk --no-cache add git
+RUN go get github.com/groob/ulidgen
+
+FROM scratch as release
+COPY --from=build /go/bin/ulidgen /bin/ulidgen
+ENTRYPOINT ["/bin/ulidgen"]

--- a/ulidgen/README.md
+++ b/ulidgen/README.md
@@ -1,0 +1,11 @@
+# 7val/ulidgen
+
+CLI utility to generate an ULID
+
+Specs: https://github.com/ulid/spec
+Code: https://github.com/groob/ulidgen
+
+## Usage
+```bash
+docker run 7val/ulidgen
+```


### PR DESCRIPTION
Wraps https://github.com/groob/ulidgen in a docker image.
The idea is to use ULID for tagging docker images in the build process or any process that needs a unique ID.