### PR TITLE
removed deprecated bats

### DIFF
--- a/bats/Dockerfile
+++ b/bats/Dockerfile
@@ -1,5 +1,0 @@
-FROM alpine:3.8 as release
-ARG BATS_VERSION="0.4.0-r2"
-RUN apk add --no-cache bats=$BATS_VERSION
-RUN bats --version
-ENTRYPOINT ["bats"]

--- a/bats/README.md
+++ b/bats/README.md
@@ -1,3 +1,0 @@
-# 7val/bats
-
-Wraps https://github.com/sstephenson/bats


### PR DESCRIPTION
The used version of Bats is deprecated and no longer maintained. Also
there is an offical image of bats-core, bats/bats. Thus this image is no
longer needed.