### PR TITLE
improve wordpress plugin/theme installation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+* schedule regular rebuilds
+* Test images
+* document local development

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -27,9 +27,9 @@ when you build it. In your `setup.sh` you can use `wp` CLI to install other plug
 
 Following environment variables are available:
 
-* `WORDPRESS_PLUGIN_LIST`: A space seperated list of plugins that should be
+* `WORDPRESS_PLUGIN_LIST`: A comma seperated list of plugins that should be
   installed. Default: empty
-* `WORDPRESS_THEME_LIST`: A spaces seperated list of themes that should be
+* `WORDPRESS_THEME_LIST`: A comma seperated list of themes that should be
   installed. Default: empty
 
 ```bash

--- a/wordpress/apache2-init.sh
+++ b/wordpress/apache2-init.sh
@@ -17,7 +17,9 @@ WORDPRESS_PLUGIN_LIST="${WORDPRESS_PLUGIN_LIST:-""}"
 # Install WP themes from ENV var WORDPRESS_THEME_LIST
 # $0
 function wp_theme_install () {
-    for theme in $WORDPRESS_THEME_LIST ; do
+    # make sure spaces work in theme names
+    local IFS=$'\n\t'
+    for theme in ${WORDPRESS_THEME_LIST//,/$'\n'} ; do
         if ! wp theme is-installed "$theme" ; then  wp theme install "$theme" ; fi
         if ! wp theme is-active "$theme" ; then wp theme activate "$theme" ; fi
     done
@@ -25,7 +27,9 @@ function wp_theme_install () {
 # Install WP plugins from ENV var WORDPRESS_PLUGIN_LIST
 # $0
 function wp_plugin_install () {
-    for plugin in $WORDPRESS_PLUGIN_LIST ; do
+    # make sure spaces work in plugin names
+    local IFS=$'\n\t'
+    for plugin in ${WORDPRESS_PLUGIN_LIST//,/$'\n'} ; do
         if ! wp plugin is-installed "$plugin" ; then  wp plugin install "$plugin" ; fi
         if ! wp plugin is-active "$plugin" ; then wp plugin activate "$plugin" ; fi
     done
@@ -33,11 +37,13 @@ function wp_plugin_install () {
 
 # Test first if WordPress is already installed. If so, skip everything else
 if wp core is-installed ; then
-  /bin/bash -c "/setup.sh"
-  echo 'wp is already installed, starting apache'
-  # exec is used in apache2-foreground, so nothing else to do here
-  apache2-foreground
-fi
+    if [[ -f /setup.sh ]] ; then
+        /bin/bash -c "/setup.sh"
+    fi
+    echo 'wp is already installed, starting apache'
+    # exec is used in apache2-foreground, so nothing else to do here
+    apache2-foreground
+    fi
 
 # Install wordpress
 wp core install \
@@ -58,7 +64,9 @@ fi
 
 wp option update blogdescription "${WORDPRESS_DESCRIPTION}"
 
-/bin/bash -c "/setup.sh"
+if [[ -f /setup.sh ]] ; then
+    /bin/bash -c "/setup.sh"
+fi
 
 # exec is used in apache2-foreground, so nothing else to do here
 # call original command

--- a/wordpress/example/Dockerfile
+++ b/wordpress/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM 7val/wordpress:5
+FROM 7val/wordpress
 COPY plugins /var/files/plugins
 COPY themes /var/files/themes
 # symlink read-only files into the /var/www/html volume


### PR DESCRIPTION
This commit changes the installation of plugins/theme via an environment
variable. Instead of a space-seperated list a comma-seperated list is
used. Thus plugins/themes with spaces in their names can be installed.

wordpress/README.md:
* adjust docs to show changed plugin/theme install

wordpress/apache2-init.sh:
* install plugins/themes via a comma sperated list
* run /setup.sh only if it exists

wordpress/example/Dockerfile:
* Remove tag from image so that latest is always used. Necessary to run
local tests.

adds TODO.md