### PR TITLE
gitlab-job: debugging install_docker-compose.sh

### DIFF
--- a/gitlab-job/install_docker-compose.sh
+++ b/gitlab-job/install_docker-compose.sh
@@ -2,6 +2,8 @@
 
 # Supposed to run under Alpines Busybox SH
 
+INSTALL_DOCKER_COMPOSE_TRACE=1
+
 # optionally set trace mode
 [[ "$INSTALL_DOCKER_COMPOSE_TRACE" ]] && set -x
 


### PR DESCRIPTION
Travis build is failing Adds set -x to install_docker-compose.sh for
debugging.