### PR TITLE
Issue #40: refactor d-c install

### DIFF
--- a/docker-test/install_docker-compose.sh
+++ b/docker-test/install_docker-compose.sh
@@ -2,14 +2,14 @@
 
 # Supposed to run under Alpines Busybox SH
 
+INSTALL_DOCKER_COMPOSE_TRACE=1
+
 # optionally set trace mode
 # shellcheck disable=SC2039
 [[ "$INSTALL_DOCKER_COMPOSE_TRACE" ]] && set -x
 
 # Sort'a strict mode
 set -euo pipefail
-
-set -x
 
 ###############################################################################
 ### define/initialize script wide variables
@@ -34,28 +34,14 @@ _bail () {
 
 ### main script
 
+# shellcheck disable=SC2039
 if [[ ! -f /.dockerenv ]] ; then
     _bail "Not running inside a Docker container"
 fi
 
-# Ugly but fast hack to get docker-compose running under Alpine
-apk add --quiet --no-cache --no-progress curl grep
-curl -s https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/latest \
-    | grep -P '^[ ]*"browser_download_url": "https://.*/glibc-[^-]+-r\d\.apk"$' \
-    | cut -d '"' -f 4 \
-    | xargs curl -sL -o /tmp/glibc.apk
-curl -s https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/latest \
-    | grep -P '^[ ]*"browser_download_url": "https://.*/glibc-bin-[^-]+-r\d\.apk"$' \
-    | cut -d '"' -f 4 \
-    | xargs curl -sL -o /tmp/glibc-bin.apk
-apk add --quiet --no-progress --allow-untrusted --no-cache \
-    /tmp/glibc.apk /tmp/glibc-bin.apk
-rm /tmp/glibc*.apk
-curl -s https://api.github.com/repos/docker/compose/releases/latest \
-    | grep -E '^[ ]*"browser_download_url": "https://.*Linux-x86_64"$' \
-    | cut -d '"' -f 4 \
-    | xargs curl -sL -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
+apk add -t d-c-install py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+pip install docker-compose
+rm -rf /root/.cache/
+apk del d-c-install
 
 # vim: ts=4 sw=4 expandtab ft=sh

--- a/docker-test/install_docker-compose.sh
+++ b/docker-test/install_docker-compose.sh
@@ -2,8 +2,6 @@
 
 # Supposed to run under Alpines Busybox SH
 
-INSTALL_DOCKER_COMPOSE_TRACE=1
-
 # optionally set trace mode
 # shellcheck disable=SC2039
 [[ "$INSTALL_DOCKER_COMPOSE_TRACE" ]] && set -x
@@ -39,9 +37,9 @@ if [[ ! -f /.dockerenv ]] ; then
     _bail "Not running inside a Docker container"
 fi
 
-apk add -t d-c-install py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
-pip install docker-compose
-rm -rf /root/.cache/
+apk add --quiet --no-progress --no-cache -t d-c-install python3-dev libffi-dev \
+    openssl-dev gcc libc-dev make
+pip3 -qqq --no-cache-dir install docker-compose
 apk del d-c-install
 
 # vim: ts=4 sw=4 expandtab ft=sh

--- a/gitlab-job/install_docker-compose.sh
+++ b/gitlab-job/install_docker-compose.sh
@@ -39,24 +39,9 @@ if [[ ! -f /.dockerenv ]] ; then
     _bail "Not running inside a Docker container"
 fi
 
-# Ugly but fast hack to get docker-compose running under Alpine
-apk add --quiet --no-cache --no-progress curl grep
-curl -s https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/latest \
-    | grep -P '^[ ]*"browser_download_url": "https://.*/glibc-[^-]+-r\d\.apk"$' \
-    | cut -d '"' -f 4 \
-    | xargs curl -sL -o /tmp/glibc.apk
-curl -s https://api.github.com/repos/sgerrand/alpine-pkg-glibc/releases/latest \
-    | grep -P '^[ ]*"browser_download_url": "https://.*/glibc-bin-[^-]+-r\d\.apk"$' \
-    | cut -d '"' -f 4 \
-    | xargs curl -sL -o /tmp/glibc-bin.apk
-apk add --quiet --no-progress --allow-untrusted --no-cache \
-    /tmp/glibc.apk /tmp/glibc-bin.apk
-rm /tmp/glibc*.apk
-curl -s https://api.github.com/repos/docker/compose/releases/latest \
-    | grep -E '^[ ]*"browser_download_url": "https://.*Linux-x86_64"$' \
-    | cut -d '"' -f 4 \
-    | xargs curl -sL -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
+apk add -t d-c-install py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+pip install docker-compose
+rm -rf /root/.cache/
+apk del d-c-install
 
 # vim: ts=4 sw=4 expandtab ft=sh

--- a/gitlab-job/install_docker-compose.sh
+++ b/gitlab-job/install_docker-compose.sh
@@ -2,8 +2,6 @@
 
 # Supposed to run under Alpines Busybox SH
 
-INSTALL_DOCKER_COMPOSE_TRACE=1
-
 # optionally set trace mode
 # shellcheck disable=SC2039
 [[ "$INSTALL_DOCKER_COMPOSE_TRACE" ]] && set -x
@@ -39,9 +37,9 @@ if [[ ! -f /.dockerenv ]] ; then
     _bail "Not running inside a Docker container"
 fi
 
-apk add -t d-c-install py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
-pip install docker-compose
-rm -rf /root/.cache/
+apk add --quiet --no-progress --no-cache -t d-c-install python3-dev libffi-dev \
+    openssl-dev gcc libc-dev make
+pip3 -qqq --no-cache-dir install docker-compose
 apk del d-c-install
 
 # vim: ts=4 sw=4 expandtab ft=sh

--- a/gitlab-job/tests/version.bats
+++ b/gitlab-job/tests/version.bats
@@ -1,0 +1,6 @@
+@test "docker-compose --version" {
+    run docker run 7val/gitlab-job docker-compose --version
+    echo "$output"
+    [[ $output =~ "docker-compose version" ]]
+    [[ $status -eq 0 ]]
+}


### PR DESCRIPTION
This commit refactors the installation of docker-compose. This is to
prevent using the Github API for finding the latest releases. Now
docker-compose is installed and build via `pip`. All build dependencies
are removed after installation. Thus the image gets only 3 MB bigger.