### PR TITLE
Fix(rancher-deployment): define default value for VOLUME_PREFIX

### DIFF
--- a/docker-compose.ops.yml
+++ b/docker-compose.ops.yml
@@ -17,8 +17,7 @@ services:
 
 
   test-images:
-    build:
-      context: ./docker-test
+    image: 7val/docker-test
     environment:
       - IMAGES
     volumes:

--- a/rancher-deployment/Dockerfile
+++ b/rancher-deployment/Dockerfile
@@ -16,8 +16,14 @@ ENV DOCKER_COMPOSE_TEMPLATE_FILE=${DOCKER_COMPOSE_TEMPLATE_FILE}
 ENV RANCHER_COMPOSE_TEMPLATE_FILE=${RANCHER_COMPOSE_TEMPLATE_FILE}
 # set to anything but not empty to setup volumes
 ENV SETUP_VOLUMES=""
+# a space-separated list of volumes that will be created if not present
+ENV VOLUME_NAMES=""
 # Optionally deploy specific service:
 ENV SERVICE=""
+
+# For testing only. Simulate the output of rancher CLI.
+# Set to one of VOLUME_NAMES to simulate a match.
+ENV TEST_VOLUME_NAME=""
 
 VOLUME /environments
 WORKDIR /work

--- a/rancher-deployment/README.md
+++ b/rancher-deployment/README.md
@@ -13,6 +13,9 @@ an `ONBUILD` [trigger][4].
   the generated files are copied to this directory. This should be
   a mounted volume to get the files out of the container. The volume **MUST NOT** be
   mounted under `/work` which is the `WORKDIR` inside the container.
+* `SETUP_VOLUMES`: Set to anything but empty to setup volumes defined in `VOLUME_NAMES`
+* `VOLUME_NAMES`: Space-separated list of volumes to create.
+  Already created volumes will be ignored. Will only run if `SETUP_VOLUMES` is set to a non-empty value.
 
 ## Test
 

--- a/rancher-deployment/docker-compose.yml
+++ b/rancher-deployment/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2.3'
 services:
-  rancher-test:
+  test:
     extends:
       file: example/docker-compose.ops.yml
       service: deploy-test

--- a/rancher-deployment/entrypoint.sh
+++ b/rancher-deployment/entrypoint.sh
@@ -24,14 +24,15 @@ if [[ -n $RANCHER_SAVE_OUTPUT_DIR ]] ; then
   cp "$RANCHER_COMPOSE_OUTPUT_FILE" "$RANCHER_SAVE_OUTPUT_DIR"
 fi
 
+if [[ -n "$SETUP_VOLUMES" ]]; then
+  . ./setup-volumes.sh
+fi
+
 if [[ -n "$DRY_RUN" ]]; then
   cat "${DOCKER_COMPOSE_OUTPUT_FILE}"
   echo "---" # signal the start of another document
   cat "${RANCHER_COMPOSE_OUTPUT_FILE}"
 else
-  if [[ -n "$SETUP_VOLUMES" ]]; then
-    . ./setup-volumes.sh
-  fi
   echo "Upgrading $ENVIRONMENT ..."
   rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --upgrade --pull -d --force-upgrade --stack "$STACK" $SERVICE
   rancher --wait-state upgraded wait

--- a/rancher-deployment/example/docker-compose.ops.yml
+++ b/rancher-deployment/example/docker-compose.ops.yml
@@ -12,5 +12,6 @@ services:
       ENVIRONMENT: "test"
       # If not set all the services will be deployed:
       SERVICE: "hello-world"
+      SETUP_VOLUMES: 1
     volumes:
       - ./environments:/environments

--- a/rancher-deployment/setup-volumes.sh
+++ b/rancher-deployment/setup-volumes.sh
@@ -7,16 +7,31 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-declare -a VOLUMES
-VOLUMES=("${VOLUME_NAMES[@]}")
+# VOLUME_NAMES is a normal variable with space-separated values
+# shellcheck disable=SC2153
+VOLUMES="$( echo "$VOLUME_NAMES" | tr ' ' '\n' )"
+VOLUME_PREFIX="${VOLUME_PREFIX:-}" # optional; default is empty
 
-for VOLUME in "${VOLUMES[@]}"; do
+echo "Try to set up rancher volumes: ${VOLUME_NAMES}"
+for VOLUME in $VOLUMES; do
   VOLUME_NAME="${VOLUME_PREFIX}${ENVIRONMENT}-${VOLUME}"
-  if rancher volume -a --format '{{.Volume.Name}}-{{.Volume.Driver}}' | grep -Fxqs "${VOLUME_NAME}-rancher-nfs"
+  if [[ -n "$DRY_RUN" ]]; then
+    vol="${VOLUME_PREFIX}${ENVIRONMENT}-${TEST_VOLUME_NAME}-rancher-nfs"
+    echo "DRY RUN: Test if '${VOLUME}' matches '${TEST_VOLUME_NAME}'."
+  else
+    echo "Check if volume ${VOLUME_NAME} exists ..."
+    vol="$( rancher volume -a --format '{{.Volume.Name}}-{{.Volume.Driver}}' )"
+  fi
+  if [[ $vol =~  ${VOLUME_NAME}-rancher-nfs ]]
   then
     echo "Volume ${VOLUME_NAME} already exists."
   else
-    echo "Create volume ${VOLUME_NAME} ..."
-    rancher volume create --driver rancher-nfs "${VOLUME_NAME}"
+    if [[ -n "$DRY_RUN" ]]; then
+      echo "DRY RUN: Would create Volume ${VOLUME_NAME}."
+    else
+      echo "Create volume ${VOLUME_NAME} ..."
+      rancher volume create --driver rancher-nfs "${VOLUME_NAME}"
+      echo "Volume ${VOLUME_NAME} created."
+    fi
   fi
 done

--- a/rancher-deployment/tests/rancher.bats
+++ b/rancher-deployment/tests/rancher.bats
@@ -1,7 +1,22 @@
 #!/usr/bin/env bats
 
-@test "d-c run test" {
-    run docker-compose run --rm rancher-test
+@test "should create volume" {
+    run docker-compose run --rm -e SETUP_VOLUMES="1" -e VOLUME_NAMES="media db" test
     echo "$output"
     [[ $status -eq 0 ]]
+    [[ "$output" =~ "Would create Volume test-media." ]]
+}
+
+@test "should not create volume" {
+    run docker-compose run --rm -e SETUP_VOLUMES="1" -e VOLUME_NAMES="media db" -e TEST_VOLUME_NAME="media" test
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ "$output" =~ "Volume test-media already exists." ]]
+}
+
+@test "should not set up volumes at all" {
+    run docker-compose run --rm -e SETUP_VOLUMES="" -e VOLUME_NAMES="media db" test
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ ! "$output" =~ "Try to set up rancher volumes" ]]
 }

--- a/rancher-deployment/tests/test.sh
+++ b/rancher-deployment/tests/test.sh
@@ -4,6 +4,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-docker-compose build rancher-test
+docker-compose build test
 trap 'docker-compose down -v --remove-orphans' ERR EXIT
 bats --tap tests/


### PR DESCRIPTION
After switching to bash strict mode the variable `VOLUME_PREFIX` throws an `unbound variable` error. Fixed by setting it to empty default value.