### PR TITLE
hotfix: fix fail when vars not set

### DIFF
--- a/rancher-deployment/entrypoint.sh
+++ b/rancher-deployment/entrypoint.sh
@@ -1,8 +1,14 @@
 #!/bin/bash -eu
 
+[[ "$RANCHER_DEPLOYMENT_TRACE" ]] && set -x
+
 DOCKER_COMPOSE_OUTPUT_FILE="./docker-compose.yml"
 RANCHER_COMPOSE_OUTPUT_FILE="./rancher-compose.yml"
 
+# Should we make a dry run
+DRY_RUN="${DRY_RUN:-}"
+# Should we setup any volumes
+SETUP_VOLUMES="${SETUP_VOLUMES:-}"
 # Name of the directory (should be a host volume) to where a copy of
 # $DOCKER_COMPOSE_OUTPUT_FILE and RANCHER_COMPOSE_OUTPUT_FILE is saved.
 RANCHER_SAVE_OUTPUT_DIR="${RANCHER_SAVE_OUTPUT_DIR:-}"
@@ -25,7 +31,8 @@ if [[ -n $RANCHER_SAVE_OUTPUT_DIR ]] ; then
 fi
 
 if [[ -n "$SETUP_VOLUMES" ]]; then
-  . ./setup-volumes.sh
+    # shellcheck disable=SC1091
+    . ./setup-volumes.sh
 fi
 
 if [[ -n "$DRY_RUN" ]]; then
@@ -34,12 +41,12 @@ if [[ -n "$DRY_RUN" ]]; then
   cat "${RANCHER_COMPOSE_OUTPUT_FILE}"
 else
   echo "Upgrading $ENVIRONMENT ..."
-  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --upgrade --pull -d --force-upgrade --stack "$STACK" $SERVICE
+  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --upgrade --pull -d --force-upgrade --stack "$STACK" "$SERVICE"
   rancher --wait-state upgraded wait
   rancher --wait-state healthy wait
 
   echo "Confirming upgrade for $ENVIRONMENT ..."
-  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --confirm-upgrade -d --stack "$STACK" $SERVICE
+  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --confirm-upgrade -d --stack "$STACK" "$SERVICE"
   rancher --wait-state active wait
   rancher --wait-state healthy wait
 fi

--- a/rancher-deployment/tests/rancher.bats
+++ b/rancher-deployment/tests/rancher.bats
@@ -20,3 +20,9 @@
     [[ $status -eq 0 ]]
     [[ ! "$output" =~ "Try to set up rancher volumes" ]]
 }
+
+@test "SETUP_VOLUMES not set should not fail" {
+    run  docker-compose run --rm test
+    echo "$output"
+    [[ $status -eq 0 ]]
+}


### PR DESCRIPTION
rancher-deployment/entrypoint.sh:
* adds DEBUG switch
* fixes fail when vars ( DRY_RUN & SETUP_VOLUMES ) are not set
* fixes Shellcheck warnings

rancher-deployment/tests/rancher.bats:
* adds test for SETUP_VOLUMES not set