### PR TITLE
hotfix: unquote $SERVICE variable

### DIFF
--- a/rancher-deployment/entrypoint.sh
+++ b/rancher-deployment/entrypoint.sh
@@ -41,12 +41,16 @@ if [[ -n "$DRY_RUN" ]]; then
   cat "${RANCHER_COMPOSE_OUTPUT_FILE}"
 else
   echo "Upgrading $ENVIRONMENT ..."
-  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --upgrade --pull -d --force-upgrade --stack "$STACK" "$SERVICE"
+  # WARNING - never ever quote $SERVICE. rancher-cli doesn't seem to like it! TODO Why?
+  # shellcheck disable=SC2086
+  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --upgrade --pull -d --force-upgrade --stack "$STACK" $SERVICE
   rancher --wait-state upgraded wait
   rancher --wait-state healthy wait
 
   echo "Confirming upgrade for $ENVIRONMENT ..."
-  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --confirm-upgrade -d --stack "$STACK" "$SERVICE"
+  # WARNING - never ever quote $SERVICE. rancher-cli doesn't seem to like it! TODO Why?
+  # shellcheck disable=SC2086
+  rancher up -f "${DOCKER_COMPOSE_OUTPUT_FILE}" --rancher-file "${RANCHER_COMPOSE_OUTPUT_FILE}" --confirm-upgrade -d --stack "$STACK" $SERVICE
   rancher --wait-state active wait
   rancher --wait-state healthy wait
 fi


### PR DESCRIPTION
This commit fixes the rancher-deployment image by unquoting the $SERVICE
variable. The quoting made every deployment fail.