### PR TITLE
Use built version for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ CURRENT_BRANCH ?= $(shell git symbolic-ref --short HEAD)
 ONLY_BRANCH ?= master
 # needed to mount files inside a container started inside a container
 HOST_PATH=$(shell pwd)
+# Unique image tag based on commit date and commit hash
+VERSION ?= $(shell git show --quiet --format="%cd-%H" --date=short)
 
 .PHONY: help
 help:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ prep-code takes care of this. The tests of the Wordpress image leverage this.
 All Bats files under `<imagename>/tests` are executed.
 
 
+
 [0]: https://github.com/sevenval/dockerfiles/blob/74ece293784680f18c89d4955a0881f93fd791f6/docker-build/run.sh#L8
 [7val/docker]: https://cloud.docker.com/u/7val/repository/docker/7val/docker
 [7val/docker-build]: https://cloud.docker.com/u/7val/repository/docker/7val/docker-build

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -21,9 +21,6 @@ if [[ -n "$DRY_RUN" ]]; then
     echo "$IMAGES"
     exit 0
 else
-    # Unique image tag based on commit date and commit hash:
-    VERSION=$(git show --quiet --format="%cd-%h" --date=short --abbrev=8)
-    COMMIT_HASH=$(git show --quiet --format="%h" --abbrev=8)
     BUILD_DATE=$(date -u +%FT%H:%M:%SZ)
 
     while IFS= read -r IMAGE_NAME
@@ -55,12 +52,9 @@ else
             --tag $TAG \\
             --tag $COMMIT_TAG \\
             --target $TARGET \\
-            --label org.label-schema.schema-version=\"1.0\" \\
-            --label org.label-schema.vendor=\"$LABEL_VENDOR\" \\
-            --label org.label-schema.vcs-url=\"$LABEL_VCS_URL\" \\
-            --label org.label-schema.vcs-ref=\"$COMMIT_HASH\" \\
-            --label org.label-schema.build-date=\"$BUILD_DATE\" \\
-            --label org.label-schema.name=\"$IMAGE_NAME\" \\
+            --label org.opencontainers.image.created=\"$BUILD_DATE\" \\
+            --label org.opencontainers.image.revision=\"$VERSION\" \\
+            --label org.opencontainers.image.url=\"$LABEL_VCS_URL\" \\
             $DOCKERFILE_FLAG \\
             $CONTEXT"
             echo "$COMMAND"

--- a/docker-build/tests/build.bats
+++ b/docker-build/tests/build.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "dry run" {
-    run docker run --rm -e IMAGES=gitlab-job -e DRY_RUN=1  7val/docker-build
+    run docker run --rm -e IMAGES=gitlab-job -e DRY_RUN=1  "7val/docker-build:$VERSION"
     [[ $status -eq 0 ]]
     [[ $output == "gitlab-job" ]]
 }

--- a/docker-compose.ops.yml
+++ b/docker-compose.ops.yml
@@ -11,6 +11,7 @@ services:
       - IMAGES
       - CACHE
       - NO_PULL
+      - VERSION
     volumes:
       - .:/work
       - /var/run/docker.sock:/var/run/docker.sock
@@ -21,6 +22,7 @@ services:
     environment:
       - IMAGES
       - HOST_PATH
+      - VERSION
     volumes:
       - ${HOST_PATH}:/work
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-push/tests/push.bats
+++ b/docker-push/tests/push.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "dry run" {
-    run docker run --rm -e IMAGES=gitlab-job -e DRY_RUN=1  7val/docker-push
+    run docker run --rm -e IMAGES=gitlab-job -e DRY_RUN=1  "7val/docker-push:$VERSION"
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output == "gitlab-job" ]]

--- a/docker/tests/docker.bats
+++ b/docker/tests/docker.bats
@@ -1,6 +1,12 @@
 @test "-c env" {
-    run docker run --rm 7val/docker -c env
+    run docker run --rm "7val/docker:$VERSION" -c env
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ "WORKDIR=/work" ]]
+}
+@test "docker version" {
+    run docker run --rm "7val/docker:$VERSION" -c 'docker --version'
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output =~ version\ 19.03.4 ]]
 }

--- a/gitlab-job/tests/version.bats
+++ b/gitlab-job/tests/version.bats
@@ -1,5 +1,5 @@
 @test "docker-compose --version" {
-    run docker run --rm 7val/gitlab-job docker-compose --version
+    run docker run --rm "7val/gitlab-job:$VERSION" docker-compose --version
     echo "$output"
     [[ $output =~ "docker-compose version" ]]
     [[ $status -eq 0 ]]

--- a/gitlab-runner/tests/runner.bats
+++ b/gitlab-runner/tests/runner.bats
@@ -4,5 +4,5 @@
     run docker run --rm --entrypoint gitlab-runner 7val/gitlab-runner --version
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output =~ Version:.*12.2.0 ]]
+    [[ $output =~ Version:.*12.4.1 ]]
 }

--- a/gitlab-runner/tests/runner.bats
+++ b/gitlab-runner/tests/runner.bats
@@ -4,5 +4,5 @@
     run docker run --rm --entrypoint gitlab-runner 7val/gitlab-runner --version
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output =~ Version:.*12.4.1 ]]
+    [[ $output =~ Version:.*12.5.0 ]]
 }

--- a/httpd-static/tests/test.sh
+++ b/httpd-static/tests/test.sh
@@ -8,7 +8,7 @@ _cleanup () {
     docker rm -f 7val-static
 }
 
-docker run -d --rm --name 7val-static --network test 7val/httpd-static
+docker run -d --rm --name 7val-static --network test "7val/httpd-static:$VERSION"
 trap _cleanup ERR EXIT
 
 sleep 1

--- a/nodejs-javascript-app/tests/node.bats
+++ b/nodejs-javascript-app/tests/node.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 @test "node version" {
-    run docker run --rm 7val/nodejs-javascript-app node --version
+    run docker run --rm "7val/nodejs-javascript-app:$VERSION" node --version
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output == "v10.0.0" ]]
+    [[ $output == "v10.15.3" ]]
 }

--- a/nodejs-javascript-builder/tests/node.bats
+++ b/nodejs-javascript-builder/tests/node.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "yarn version" {
-    run docker run --rm 7val/nodejs-javascript-builder yarn --version
+    run docker run --rm "7val/nodejs-javascript-builder:$VERSION" yarn --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output == "1.15.0" ]]

--- a/nodejs-javascript-hello/yarn.lock
+++ b/nodejs-javascript-hello/yarn.lock
@@ -140,6 +140,11 @@ extend@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 for-each@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"

--- a/nodejs-runner/tests/node.bats
+++ b/nodejs-runner/tests/node.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "node version" {
-    run docker run --rm 7val/nodejs-runner node --version
+    run docker run --rm "7val/nodejs-runner:$VERSION" node --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output == "v10.15.3" ]]

--- a/sloppy/tests/sloppy.bats
+++ b/sloppy/tests/sloppy.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "sloppy version" {
-    run docker run --rm 7val/sloppy
+    run docker run --rm "7val/sloppy:$VERSION"
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output == "1.13.1" ]]

--- a/ulidgen/tests/ulid.bats
+++ b/ulidgen/tests/ulid.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "generate ULID" {
-    run docker run --rm 7val/ulidgen
+    run docker run --rm "7val/ulidgen:$VERSION"
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $( echo -n "$output" | wc -m ) -eq 26 ]]


### PR DESCRIPTION
* Most tests no longer use the latest tag. Instead $VERSION defined in Makefile
  (the current Git HEAD) is used.
* Build: switch to opencaontainers labels
* adds version test to 7val/docker image
* some version updates: gitlab-runner, node
* security update exend module in nodejs-javascript-hello/yarn.lock