### PR TITLE
replace versioned docker base image with unversioned

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM koalaman/shellcheck-alpine:v0.6.0 as test
 COPY *.sh ./
 RUN find . -name "*.sh" | xargs shellcheck
 
-FROM docker:19.03.4-git AS release
+FROM docker:git AS release
 ENV WORKDIR=/work
 WORKDIR ${WORKDIR}
 VOLUME ${WORKDIR}

--- a/docker/tests/docker.bats
+++ b/docker/tests/docker.bats
@@ -8,5 +8,5 @@
     run docker run --rm "7val/docker:$VERSION" -c 'docker --version'
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output =~ version\ 19.03.4 ]]
+    [[ $output =~ version\ 19.03.5 ]]
 }


### PR DESCRIPTION
This commit replaces the versioned base image for our docker image with
an unversioned one. Since the tests check the version we always get
updates and know when an update happens.