### PR TITLE
gitlab-runner/automatic unregistering

### DIFF
--- a/gitlab-runner/README.md
+++ b/gitlab-runner/README.md
@@ -4,12 +4,13 @@
 ![size](https://images.microbadger.com/badges/image/7val/gitlab-runner.svg)
 [![commit](https://images.microbadger.com/badges/commit/7val/gitlab-runner.svg)](https://microbadger.com/images/7val/gitlab-runner)
 
-A gitlab-runner with automatic registration.
+A gitlab-runner with automatic registration and unregistration.
 
 ## Usage
 
-To spawn a runner locally just execute:
+To spawn a runner just execute:
 ```bash
 docker run -e CI_SERVER_URL=https://gitlab.com -e REGISTRATION_TOKEN=<your-token> 7val/gitlab-runner
 ```
-You can pass all the environment variables defined by the [gitlab-runner commands](https://docs.gitlab.com/runner/commands/).
+You can pass all the environment variables defined by the
+[gitlab-runner commands](https://docs.gitlab.com/runner/commands/).

--- a/gitlab-runner/tests/runner.bats
+++ b/gitlab-runner/tests/runner.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "gitlab-runner --version" {
-    run docker run --rm --entrypoint gitlab-runner 7val/gitlab-runner --version
+    run docker run --rm --entrypoint gitlab-runner "7val/gitlab-runner:$VERSION" --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ Version:.*12.5.0 ]]


### PR DESCRIPTION
This commit adds functionality to the runner that automatically
unregisters the runner when it is stopped. Thus no dead runners are left
in Gitlab-CI.