### PR TITLE
remove exit

### DIFF
--- a/gitlab-runner/register-runner.sh
+++ b/gitlab-runner/register-runner.sh
@@ -12,7 +12,6 @@ RUNNER_NAME=${RUNNER_NAME:-$HOSTNAME}
 function _unregister () {
     local name="$1"
     gitlab-runner unregister --name "$name"
-    exit 0
 }
 
 gitlab-runner verify --name "${RUNNER_NAME}"

--- a/gitlab-runner/tests/runner.bats
+++ b/gitlab-runner/tests/runner.bats
@@ -4,5 +4,5 @@
     run docker run --rm --entrypoint gitlab-runner "7val/gitlab-runner:$VERSION" --version
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output =~ Version:.*12.5.0 ]]
+    [[ $output =~ Version:.*12.7.1 ]]
 }


### PR DESCRIPTION
This commit removes the exit inside the _unregister function. The exit
made it impossible to use the funtion outside of trap, since will always
end the container.